### PR TITLE
feat: 상담내역 탭 UI/UX 개선

### DIFF
--- a/app/(tabs)/sessions.tsx
+++ b/app/(tabs)/sessions.tsx
@@ -1,9 +1,9 @@
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { router } from 'expo-router';
-import { useCallback, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
-import { SegmentedButtons, Text } from 'react-native-paper';
+import { useCallback, useEffect, useState } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { Text } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import SessionCard from '@/components/session/SessionCard';
 import SessionListContainer from '@/components/session/SessionListContainer';
 import { spacing } from '@/constants/theme';
 import { useSessions } from '@/hooks/useSessions';
@@ -16,30 +16,67 @@ export default function SessionsScreen() {
   const toast = useToast();
   const [tabIndex, setTabIndex] = useState('0');
 
+  // 페이지네이션 상태
+  const [activePage, setActivePage] = useState(1);
+  const [closedPage, setClosedPage] = useState(1);
+  const [bookmarkedPage, setBookmarkedPage] = useState(1);
+
+  // 누적 세션 데이터
+  const [allActiveSessions, setAllActiveSessions] = useState<Session[]>([]);
+  const [allClosedSessions, setAllClosedSessions] = useState<Session[]>([]);
+  const [allBookmarkedSessions, setAllBookmarkedSessions] = useState<Session[]>([]);
+
   // 진행중 세션
   const {
     data: activeData,
     isLoading: activeLoading,
     refetch: refetchActive,
-  } = useSessions(1, 20, undefined, false);
+  } = useSessions(activePage, 10, undefined, false);
 
   // 종료된 세션
   const {
     data: closedData,
     isLoading: closedLoading,
     refetch: refetchClosed,
-  } = useSessions(1, 20, undefined, true);
+  } = useSessions(closedPage, 10, undefined, true);
 
   // 북마크된 세션
   const {
     data: bookmarkedData,
     isLoading: bookmarkedLoading,
     refetch: refetchBookmarked,
-  } = useSessions(1, 20, true, undefined);
+  } = useSessions(bookmarkedPage, 10, true, undefined);
 
-  const activeSessions = activeData?.content || [];
-  const closedSessions = closedData?.content || [];
-  const bookmarkedSessions = bookmarkedData?.content || [];
+  // 데이터가 로드되면 누적 배열에 추가
+  useEffect(() => {
+    if (activeData?.content) {
+      if (activePage === 1) {
+        setAllActiveSessions(activeData.content);
+      } else {
+        setAllActiveSessions(prev => [...prev, ...activeData.content]);
+      }
+    }
+  }, [activeData, activePage]);
+
+  useEffect(() => {
+    if (closedData?.content) {
+      if (closedPage === 1) {
+        setAllClosedSessions(closedData.content);
+      } else {
+        setAllClosedSessions(prev => [...prev, ...closedData.content]);
+      }
+    }
+  }, [closedData, closedPage]);
+
+  useEffect(() => {
+    if (bookmarkedData?.content) {
+      if (bookmarkedPage === 1) {
+        setAllBookmarkedSessions(bookmarkedData.content);
+      } else {
+        setAllBookmarkedSessions(prev => [...prev, ...bookmarkedData.content]);
+      }
+    }
+  }, [bookmarkedData, bookmarkedPage]);
 
   const handleBookmarkToggle = useCallback(
     async (sessionId: number) => {
@@ -66,80 +103,105 @@ export default function SessionsScreen() {
     router.push('/(tabs)/');
   }, []);
 
-  const renderActiveSession = useCallback(
-    (session: Session) => (
-      <SessionCard
-        key={session.sessionId}
-        session={session}
-        variant="active"
-        onBookmarkToggle={() => handleBookmarkToggle(session.sessionId)}
-      />
-    ),
-    [handleBookmarkToggle],
-  );
+  // 무한 스크롤 핸들러
+  const handleLoadMoreActive = useCallback(() => {
+    if (!activeLoading && activeData?.pageInfo?.hasNext) {
+      setActivePage(prev => prev + 1);
+    }
+  }, [activeLoading, activeData]);
 
-  const renderClosedSession = useCallback(
-    (session: Session) => (
-      <SessionCard
-        key={session.sessionId}
-        session={session}
-        variant="closed"
-        onBookmarkToggle={() => handleBookmarkToggle(session.sessionId)}
-      />
-    ),
-    [handleBookmarkToggle],
-  );
+  const handleLoadMoreClosed = useCallback(() => {
+    if (!closedLoading && closedData?.pageInfo?.hasNext) {
+      setClosedPage(prev => prev + 1);
+    }
+  }, [closedLoading, closedData]);
 
-  const renderBookmarkedSession = useCallback(
-    (session: Session) => (
-      <SessionCard
-        key={session.sessionId}
-        session={session}
-        variant="bookmarked"
-        onBookmarkToggle={() => handleBookmarkToggle(session.sessionId)}
-      />
-    ),
-    [handleBookmarkToggle],
-  );
+  const handleLoadMoreBookmarked = useCallback(() => {
+    if (!bookmarkedLoading && bookmarkedData?.pageInfo?.hasNext) {
+      setBookmarkedPage(prev => prev + 1);
+    }
+  }, [bookmarkedLoading, bookmarkedData]);
+
+  // 새로고침 핸들러
+  const handleRefreshActive = useCallback(() => {
+    setActivePage(1);
+    refetchActive();
+  }, [refetchActive]);
+
+  const handleRefreshClosed = useCallback(() => {
+    setClosedPage(1);
+    refetchClosed();
+  }, [refetchClosed]);
+
+  const handleRefreshBookmarked = useCallback(() => {
+    setBookmarkedPage(1);
+    refetchBookmarked();
+  }, [refetchBookmarked]);
 
   return (
     <View style={[styles.container, { paddingTop: insets.top }]}>
       <View style={styles.header}>
-        <Text style={styles.title}>상담 내역</Text>
-        <Text style={styles.subtitle}>나의 상담 기록을 확인하세요</Text>
-      </View>
+        <View style={styles.titleSection}>
+          <View style={styles.iconContainer}>
+            <MaterialCommunityIcons name="clipboard-text-multiple" size={20} color="#6B46C1" />
+          </View>
+          <Text style={styles.title}>상담 내역</Text>
+        </View>
 
-      <View style={styles.tabContainer}>
-        <SegmentedButtons
-          value={tabIndex}
-          onValueChange={setTabIndex}
-          buttons={[
-            {
-              value: '0',
-              label: '진행중',
-              icon: 'chat-processing',
-            },
-            {
-              value: '1',
-              label: '종료됨',
-              icon: 'check-circle',
-            },
-            {
-              value: '2',
-              label: '북마크',
-              icon: 'star',
-            },
-          ]}
-          style={styles.segmentedButtons}
-        />
+        <View style={styles.chipContainer}>
+          <Pressable
+            style={[styles.chip, tabIndex === '0' && styles.chipActive]}
+            onPress={() => setTabIndex('0')}
+          >
+            <MaterialCommunityIcons
+              name="chat-processing"
+              size={14}
+              color={tabIndex === '0' ? '#FFFFFF' : '#6B7280'}
+            />
+            <Text style={[styles.chipText, tabIndex === '0' && styles.chipTextActive]}>
+              진행중
+            </Text>
+          </Pressable>
+
+          <Pressable
+            style={[styles.chip, tabIndex === '1' && styles.chipActive]}
+            onPress={() => setTabIndex('1')}
+          >
+            <MaterialCommunityIcons
+              name="check-circle"
+              size={14}
+              color={tabIndex === '1' ? '#FFFFFF' : '#6B7280'}
+            />
+            <Text style={[styles.chipText, tabIndex === '1' && styles.chipTextActive]}>
+              종료됨
+            </Text>
+          </Pressable>
+
+          <Pressable
+            style={[styles.chip, tabIndex === '2' && styles.chipActive]}
+            onPress={() => setTabIndex('2')}
+          >
+            <MaterialCommunityIcons
+              name="star"
+              size={14}
+              color={tabIndex === '2' ? '#FFFFFF' : '#6B7280'}
+            />
+            <Text style={[styles.chipText, tabIndex === '2' && styles.chipTextActive]}>
+              북마크
+            </Text>
+          </Pressable>
+        </View>
       </View>
 
       <View style={styles.content}>
         {tabIndex === '0' && (
           <SessionListContainer
-            sessions={activeSessions}
-            isLoading={activeLoading}
-            onRefresh={refetchActive}
+            sessions={allActiveSessions}
+            isLoading={activeLoading && activePage === 1}
+            isRefreshing={false}
+            hasMore={activeData?.pageInfo?.hasNext}
+            onRefresh={handleRefreshActive}
+            onEndReached={handleLoadMoreActive}
             emptyIcon="chat-processing"
             emptyTitle="진행 중인 상담이 없습니다"
             emptySubtitle="새로운 상담을 시작해보세요!"
@@ -147,31 +209,40 @@ export default function SessionsScreen() {
               label: '상담 시작하기',
               onPress: handleNewSession,
             }}
-            renderItem={renderActiveSession}
+            onBookmarkToggle={handleBookmarkToggle}
+            layoutMode="grid"
           />
         )}
 
         {tabIndex === '1' && (
           <SessionListContainer
-            sessions={closedSessions}
-            isLoading={closedLoading}
-            onRefresh={refetchClosed}
+            sessions={allClosedSessions}
+            isLoading={closedLoading && closedPage === 1}
+            isRefreshing={false}
+            hasMore={closedData?.pageInfo?.hasNext}
+            onRefresh={handleRefreshClosed}
+            onEndReached={handleLoadMoreClosed}
             emptyIcon="check-circle"
             emptyTitle="종료된 상담이 없습니다"
             emptySubtitle="상담을 완료하면 여기에 표시됩니다"
-            renderItem={renderClosedSession}
+            onBookmarkToggle={handleBookmarkToggle}
+            layoutMode="grid"
           />
         )}
 
         {tabIndex === '2' && (
           <SessionListContainer
-            sessions={bookmarkedSessions}
-            isLoading={bookmarkedLoading}
-            onRefresh={refetchBookmarked}
+            sessions={allBookmarkedSessions}
+            isLoading={bookmarkedLoading && bookmarkedPage === 1}
+            isRefreshing={false}
+            hasMore={bookmarkedData?.pageInfo?.hasNext}
+            onRefresh={handleRefreshBookmarked}
+            onEndReached={handleLoadMoreBookmarked}
             emptyIcon="star"
             emptyTitle="북마크한 상담이 없습니다"
             emptySubtitle="중요한 상담은 ⭐을 눌러 저장하세요"
-            renderItem={renderBookmarkedSession}
+            onBookmarkToggle={handleBookmarkToggle}
+            layoutMode="grid"
           />
         )}
       </View>
@@ -185,33 +256,73 @@ const styles = StyleSheet.create({
     backgroundColor: '#F9FAFB',
   },
   header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
     paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.md,
+    paddingVertical: spacing.sm + 2,
     backgroundColor: 'white',
     borderBottomWidth: 1,
-    borderBottomColor: '#E5E7EB',
+    borderBottomColor: '#F3F4F6',
+    elevation: 2,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+  },
+  titleSection: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  iconContainer: {
+    width: 32,
+    height: 32,
+    borderRadius: 8,
+    backgroundColor: 'rgba(107, 70, 193, 0.1)',
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   title: {
-    fontSize: 24,
+    fontSize: 20,
     fontWeight: '700',
     fontFamily: 'Pretendard-Bold',
     color: '#111827',
+    letterSpacing: -0.3,
   },
-  subtitle: {
-    fontSize: 14,
-    fontFamily: 'Pretendard-Regular',
+  chipContainer: {
+    flexDirection: 'row',
+    gap: 6,
+    marginLeft: spacing.md,
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 16,
+    backgroundColor: '#F9FAFB',
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  chipActive: {
+    backgroundColor: '#6B46C1',
+    borderColor: '#6B46C1',
+    elevation: 2,
+    shadowColor: '#6B46C1',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+  },
+  chipText: {
+    fontSize: 12,
+    fontFamily: 'Pretendard-Medium',
     color: '#6B7280',
-    marginTop: 4,
   },
-  tabContainer: {
-    backgroundColor: 'white',
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.sm,
-    borderBottomWidth: 1,
-    borderBottomColor: '#E5E7EB',
-  },
-  segmentedButtons: {
-    backgroundColor: 'transparent',
+  chipTextActive: {
+    color: '#FFFFFF',
+    fontFamily: 'Pretendard-SemiBold',
   },
   content: {
     flex: 1,

--- a/components/chat/ChatHeader.tsx
+++ b/components/chat/ChatHeader.tsx
@@ -1,7 +1,8 @@
 import { router } from 'expo-router';
 import React from 'react';
-import { Image, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Image, StyleSheet, View } from 'react-native';
 import { IconButton, Text } from 'react-native-paper';
+import { AnimatedButton } from '@/components/common/AnimatedButton';
 import { getCounselorImage } from '@/constants/counselorImages';
 import { spacing } from '@/constants/theme';
 
@@ -34,14 +35,13 @@ export const ChatHeader = React.memo(
           <View style={styles.counselorInfo}>
             {avatarSource && <Image source={avatarSource} style={styles.avatar} />}
             <View style={styles.textContainer}>
-              {counselorName && <Text style={styles.counselorName}>{counselorName} 상담사</Text>}
               <View style={styles.titleContainer}>
                 <Text style={styles.title} numberOfLines={1}>
-                  {title || '새 대화'}
+                  {title || '새 상담'}
                 </Text>
-                <TouchableOpacity onPress={onTitleEdit} style={styles.editButton}>
+                <AnimatedButton onPress={onTitleEdit} style={styles.editButton} scaleTo={0.85} springConfig={{ damping: 15, stiffness: 200 }}>
                   <IconButton icon="pencil-outline" size={16} />
-                </TouchableOpacity>
+                </AnimatedButton>
               </View>
             </View>
           </View>
@@ -64,7 +64,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     paddingHorizontal: spacing.xs,
-    paddingVertical: spacing.md,
+    paddingVertical: spacing.sm, // 16px → 8px로 줄임
     backgroundColor: 'white',
     borderBottomWidth: 1,
     borderBottomColor: '#E5E7EB',
@@ -83,9 +83,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   avatar: {
-    width: 44,
-    height: 44,
-    borderRadius: 22,
+    width: 40, // 44 → 40으로 약간 줄임
+    height: 40,
+    borderRadius: 20,
     marginRight: spacing.sm,
     borderWidth: 1,
     borderColor: '#6B46C1',
@@ -94,8 +94,8 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   counselorName: {
-    fontSize: 12,
-    fontFamily: 'Pretendard-Medium',
+    fontSize: 15, // 사용하지 않지만 남겨둠
+    fontFamily: 'Pretendard-Bold',
     color: '#6B46C1',
     marginBottom: 2,
   },
@@ -104,10 +104,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   title: {
-    fontSize: 16,
-    fontFamily: 'Pretendard-SemiBold',
-    color: '#111827',
-    maxWidth: '80%',
+    fontSize: 16, // 원래 크기로 복원
+    fontFamily: 'Pretendard-SemiBold', // 원래 굵기로 복원
+    color: '#111827', // 원래 색상으로 복원
+    maxWidth: '85%',
   },
   editButton: {
     marginLeft: -8,

--- a/components/common/StarRating.tsx
+++ b/components/common/StarRating.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { Text } from 'react-native-paper';
+import { AnimatedButton } from '@/components/common/AnimatedButton';
 import { spacing } from '@/constants/theme';
 
 interface StarRatingProps {
@@ -30,10 +31,11 @@ export const StarRating = React.memo(
             {!readOnly && (
               <View style={[styles.starOverlay, { width: size, height: size }]}>
                 {/* 왼쪽 반개 */}
-                <TouchableOpacity
+                <AnimatedButton
                   style={[styles.halfStarTouchLeft, { width: size / 2, height: size }]}
                   onPress={() => onRatingChange(i - 0.5)}
-                  activeOpacity={0.7}
+                  scaleTo={0.9}
+                  springConfig={{ damping: 20, stiffness: 300 }}
                 >
                   {(isHalfFilled || isFullFilled) && (
                     <View style={[styles.halfStarLeftFill, { width: size / 2, height: size }]}>
@@ -48,13 +50,14 @@ export const StarRating = React.memo(
                       </Text>
                     </View>
                   )}
-                </TouchableOpacity>
+                </AnimatedButton>
 
                 {/* 오른쪽 반개 */}
-                <TouchableOpacity
+                <AnimatedButton
                   style={[styles.halfStarTouchRight, { width: size / 2, height: size }]}
                   onPress={() => onRatingChange(i)}
-                  activeOpacity={0.7}
+                  scaleTo={0.9}
+                  springConfig={{ damping: 20, stiffness: 300 }}
                 >
                   {isFullFilled && (
                     <View style={[styles.halfStarRightFill, { width: size / 2, height: size }]}>
@@ -70,7 +73,7 @@ export const StarRating = React.memo(
                       </Text>
                     </View>
                   )}
-                </TouchableOpacity>
+                </AnimatedButton>
               </View>
             )}
 

--- a/components/counselor/FavoriteCounselorCard.tsx
+++ b/components/counselor/FavoriteCounselorCard.tsx
@@ -1,16 +1,23 @@
 import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { router } from 'expo-router';
 import React, { useCallback } from 'react';
-import { Dimensions, Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Dimensions, StyleSheet, Text, View } from 'react-native';
+import { AnimatedButton } from '@/components/common/AnimatedButton';
 import { getCounselorImage } from '@/constants/counselorImages';
 import { spacing } from '@/constants/theme';
 import type { FavoriteCounselorResponse } from '@/services/counselors/types';
 
 const { width: screenWidth, height: screenHeight } = Dimensions.get('window');
-// 화면 너비에서 padding을 뺀 후 2로 나누고, 카드 간격 고려
-const CARD_WIDTH = (screenWidth - spacing.lg * 2 - spacing.sm) / 2;
-const CARD_HEIGHT = (screenHeight - 220) / 2; // 화면 높이에서 헤더, 탭바 등 제외하고 2행으로 나눔
+// 즐겨찾기 카드: 화면을 반응형으로 꽉 채움
+export const CARD_WIDTH = (screenWidth - spacing.lg * 2 - spacing.sm) / 2; // 정확히 2개씩
+// 헤더와 탭바를 제외한 실제 콘텐츠 영역의 절반 크기로 설정
+const availableHeight = screenHeight - 180; // 헤더, 탭바, 여백 제외
+export const CARD_HEIGHT = Math.max(
+  CARD_WIDTH * 1.5, // 최소 비율
+  Math.min(availableHeight * 0.48, CARD_WIDTH * 1.8) // 최대 48% 또는 1.8 비율
+);
 
 interface FavoriteCounselorCardProps {
   counselor: FavoriteCounselorResponse;
@@ -27,11 +34,11 @@ export const FavoriteCounselorCard = React.memo(
     const imageSource = getCounselorImage(counselor.avatarUrl);
 
     return (
-      <TouchableOpacity onPress={handlePress} activeOpacity={0.9}>
+      <AnimatedButton onPress={handlePress} scaleTo={0.96} springConfig={{ damping: 12, stiffness: 160 }}>
         <View style={styles.card}>
           {/* 이미지가 카드 전체를 차지 */}
           {imageSource ? (
-            <Image source={imageSource} style={styles.fullImage} resizeMode="cover" />
+            <Image source={imageSource} style={styles.fullImage} contentFit="cover" transition={200} />
           ) : (
             <LinearGradient
               colors={['#EC4899', '#F472B6']}
@@ -44,20 +51,21 @@ export const FavoriteCounselorCard = React.memo(
           )}
 
           {/* 그라데이션 오버레이 (하단 어둡게) */}
-          <LinearGradient colors={['transparent', 'rgba(0,0,0,0.7)']} style={styles.overlay} />
+          <LinearGradient colors={['transparent', 'rgba(0,0,0,0.6)']} style={styles.overlay} />
 
           {/* 하트 아이콘 - 클릭시 즐겨찾기 해제 */}
-          <TouchableOpacity
+          <AnimatedButton
             style={styles.heartBadge}
             onPress={(e) => {
               e.stopPropagation(); // 카드 클릭 이벤트와 분리
               onFavoriteToggle?.();
             }}
-            activeOpacity={0.7}
+            scaleTo={0.85}
+            springConfig={{ damping: 15, stiffness: 200 }}
             hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
           >
             <MaterialCommunityIcons name="heart" size={16} color="#FFFFFF" />
-          </TouchableOpacity>
+          </AnimatedButton>
 
           {/* 하단 정보 영역 */}
           <View style={styles.infoContainer}>
@@ -77,7 +85,7 @@ export const FavoriteCounselorCard = React.memo(
             </View>
           </View>
         </View>
-      </TouchableOpacity>
+      </AnimatedButton>
     );
   },
 );
@@ -89,7 +97,7 @@ const styles = StyleSheet.create({
     marginRight: spacing.sm,
     borderRadius: 16,
     overflow: 'hidden',
-    backgroundColor: '#000',
+    backgroundColor: '#F3F4F6',
     elevation: 6,
     shadowColor: '#000',
     shadowOffset: {
@@ -106,7 +114,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#F3F4F6',
   },
   avatarPlaceholder: {
-    fontSize: CARD_WIDTH * 0.3,
+    fontSize: CARD_WIDTH * 0.25,
     fontWeight: '700',
     fontFamily: 'Pretendard-Bold',
     color: '#FFFFFF',
@@ -118,7 +126,7 @@ const styles = StyleSheet.create({
     bottom: 0,
     left: 0,
     right: 0,
-    height: CARD_HEIGHT * 0.4,
+    height: '35%',
   },
   heartBadge: {
     position: 'absolute',

--- a/components/counselor/ProfileHeader.tsx
+++ b/components/counselor/ProfileHeader.tsx
@@ -2,8 +2,9 @@ import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
 import { router } from 'expo-router';
 import React from 'react';
-import { Image, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Image, StyleSheet, View } from 'react-native';
 import { Text } from 'react-native-paper';
+import { AnimatedButton } from '@/components/common/AnimatedButton';
 import { getCounselorImage } from '@/constants/counselorImages';
 import { spacing } from '@/constants/theme';
 import type { CounselorDetail } from '@/services/counselors/types';
@@ -23,9 +24,9 @@ export const ProfileHeader = React.memo(({ counselor }: ProfileHeaderProps) => {
       style={styles.header}
     >
       <View style={styles.headerTop}>
-        <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+        <AnimatedButton onPress={() => router.back()} style={styles.backButton} scaleTo={0.88} springConfig={{ damping: 15, stiffness: 200 }}>
           <MaterialCommunityIcons name="arrow-left" size={24} color="white" />
-        </TouchableOpacity>
+        </AnimatedButton>
       </View>
 
       <View style={styles.profileSection}>

--- a/components/favorites/FavoritesEmptyState.tsx
+++ b/components/favorites/FavoritesEmptyState.tsx
@@ -1,8 +1,9 @@
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import React, { useCallback } from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { Text } from 'react-native-paper';
+import { AnimatedButton } from '@/components/common/AnimatedButton';
 import { spacing } from '@/constants/theme';
 
 interface FavoritesEmptyStateProps {
@@ -25,11 +26,11 @@ export const FavoritesEmptyState = React.memo(({ isAuthenticated }: FavoritesEmp
           ? '로그인하고 마음에 드는 상담사를 저장해보세요'
           : '마음에 드는 철학자를 즐겨찾기에 추가해보세요'}
       </Text>
-      <TouchableOpacity style={styles.browseButton} onPress={handleStartChat}>
+      <AnimatedButton style={styles.browseButton} onPress={handleStartChat} scaleTo={0.95} springConfig={{ damping: 12, stiffness: 160 }}>
         <Text style={styles.browseButtonText}>
           {!isAuthenticated ? '로그인하기' : '상담사 둘러보기'}
         </Text>
-      </TouchableOpacity>
+      </AnimatedButton>
     </View>
   );
 });

--- a/components/favorites/FavoritesHeader.tsx
+++ b/components/favorites/FavoritesHeader.tsx
@@ -1,4 +1,4 @@
-import { LinearGradient } from 'expo-linear-gradient';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Text } from 'react-native-paper';
@@ -6,41 +6,61 @@ import { spacing } from '@/constants/theme';
 
 export const FavoritesHeader = React.memo(() => {
   return (
-    <LinearGradient
-      colors={['#FFFFFF', '#FAF5FF']}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 1, y: 1 }}
-      style={styles.header}
-    >
+    <View style={styles.header}>
       <View style={styles.headerContent}>
-        <Text style={styles.title}>✨ 즐겨찾기</Text>
-        <Text style={styles.subtitle}>자주 상담받는 철학자들을 모아보세요</Text>
+        <View style={styles.topRow}>
+          <View style={styles.titleContainer}>
+            <View style={styles.iconContainer}>
+              <MaterialCommunityIcons name="heart" size={20} color="#EC4899" />
+            </View>
+            <Text style={styles.title}>즐겨찾기</Text>
+          </View>
+        </View>
+        <View style={styles.divider} />
       </View>
-    </LinearGradient>
+    </View>
   );
 });
 
 const styles = StyleSheet.create({
   header: {
     paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.md,
-    borderBottomWidth: 1,
-    borderBottomColor: 'rgba(229, 231, 235, 0.3)',
-    marginBottom: spacing.xs,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.sm,
+    backgroundColor: '#FFFFFF',
   },
   headerContent: {
+    alignItems: 'flex-start',
+  },
+  topRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    width: '100%',
+    marginBottom: spacing.sm,
+  },
+  titleContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  iconContainer: {
+    width: 32,
+    height: 32,
+    borderRadius: 8,
+    backgroundColor: 'rgba(236, 72, 153, 0.1)',
+    justifyContent: 'center',
     alignItems: 'center',
   },
   title: {
-    fontSize: 24,
+    fontSize: 20,
     fontWeight: '700',
     fontFamily: 'Pretendard-Bold',
     color: '#111827',
-    marginBottom: 4,
+    letterSpacing: -0.3,
   },
-  subtitle: {
-    fontSize: 13,
-    fontFamily: 'Pretendard-Regular',
-    color: '#6B7280',
+  divider: {
+    height: 1,
+    backgroundColor: '#F3F4F6',
+    width: '100%',
   },
 });

--- a/components/favorites/FavoritesList.tsx
+++ b/components/favorites/FavoritesList.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, RefreshControl, ScrollView, StyleSheet, View } from 'react-native';
+import { CARD_WIDTH } from '@/components/counselor/FavoriteCounselorCard';
 import { spacing } from '@/constants/theme';
 import type { FavoriteCounselorResponse } from '@/services/counselors/types';
 import { FavoritesEmptyState } from './FavoritesEmptyState';
@@ -27,6 +28,10 @@ export const FavoritesList = React.memo(
     // 스크롤 힌트 애니메이션
     const scrollHintAnim = useRef(new Animated.Value(1)).current;
     const [showScrollHint, setShowScrollHint] = useState(true);
+
+    // Active pagination dots state
+    const [activeIndex1, setActiveIndex1] = useState(0);
+    const [activeIndex2, setActiveIndex2] = useState(0);
 
     // 초기 진입시 스크롤 힌트 애니메이션
     useEffect(() => {
@@ -74,8 +79,22 @@ export const FavoritesList = React.memo(
       return [row1, row2];
     }, [favorites, isLoading]);
 
-    const handleScroll = () => {
+    const handleScrollRow1 = (event?: any) => {
       setShowScrollHint(false);
+      if (event?.nativeEvent) {
+        const { contentOffset } = event.nativeEvent;
+        const index = Math.round(contentOffset.x / (CARD_WIDTH + spacing.sm));
+        setActiveIndex1(Math.max(0, index));
+      }
+    };
+
+    const handleScrollRow2 = (event?: any) => {
+      setShowScrollHint(false);
+      if (event?.nativeEvent) {
+        const { contentOffset } = event.nativeEvent;
+        const index = Math.round(contentOffset.x / (CARD_WIDTH + spacing.sm));
+        setActiveIndex2(Math.max(0, index));
+      }
     };
 
     if (!isAuthenticated || (favorites.length === 0 && !isLoading)) {
@@ -103,9 +122,10 @@ export const FavoritesList = React.memo(
             showScrollHint={showScrollHint}
             scrollHintAnim={scrollHintAnim}
             onFavoriteToggle={onFavoriteToggle}
-            onScroll={handleScroll}
+            onScroll={handleScrollRow1}
             rowKey="row1"
             hintColor="#6B46C1"
+            activeIndex={activeIndex1}
           />
 
           {secondRow.length > 0 && (
@@ -115,9 +135,10 @@ export const FavoritesList = React.memo(
               showScrollHint={showScrollHint}
               scrollHintAnim={scrollHintAnim}
               onFavoriteToggle={onFavoriteToggle}
-              onScroll={handleScroll}
+              onScroll={handleScrollRow2}
               rowKey="row2"
               hintColor="#EC4899"
+              activeIndex={activeIndex2}
             />
           )}
         </View>
@@ -132,10 +153,12 @@ const styles = StyleSheet.create({
     backgroundColor: '#F9FAFB',
   },
   contentContainer: {
-    flexGrow: 1,
+    flex: 1,
+    justifyContent: 'center',
   },
   rowsContainer: {
     flex: 1,
-    paddingVertical: spacing.sm,
+    justifyContent: 'center',
+    gap: spacing.lg, // 1행과 2행 사이 충분한 여백 (24px)
   },
 });

--- a/components/home/CategoryGrid.tsx
+++ b/components/home/CategoryGrid.tsx
@@ -3,6 +3,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { Text } from 'react-native-paper';
+import { AnimatedButton } from '@/components/common/AnimatedButton';
 import Reanimated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 import { CATEGORIES } from '@/constants/categories';
 import { spacing } from '@/constants/theme';
@@ -136,9 +137,11 @@ export const CategoryGrid = React.memo(
 
           {/* 더보기 버튼 - 전체 너비로 */}
           {!showAllCategories && (
-            <TouchableOpacity
+            <AnimatedButton
               style={styles.moreButtonFull}
               onPress={() => setShowAllCategories(true)}
+              scaleTo={0.96}
+              springConfig={{ damping: 12, stiffness: 160 }}
             >
               <Text style={styles.moreButtonText}>더 많은 카테고리 보기</Text>
               <Animated.View
@@ -155,7 +158,7 @@ export const CategoryGrid = React.memo(
               >
                 <MaterialCommunityIcons name="chevron-down" size={20} color="#6B7280" />
               </Animated.View>
-            </TouchableOpacity>
+            </AnimatedButton>
           )}
 
           {/* 추가 카테고리 (12개) - 확장 시 표시 */}
@@ -176,13 +179,15 @@ export const CategoryGrid = React.memo(
               </View>
 
               {/* 접기 버튼 */}
-              <TouchableOpacity
+              <AnimatedButton
                 style={styles.collapseButton}
                 onPress={() => setShowAllCategories(false)}
+                scaleTo={0.94}
+                springConfig={{ damping: 15, stiffness: 200 }}
               >
                 <Text style={styles.collapseButtonText}>접기</Text>
                 <MaterialCommunityIcons name="chevron-up" size={20} color="#6B7280" />
-              </TouchableOpacity>
+              </AnimatedButton>
             </Animated.View>
           )}
         </View>

--- a/components/home/CounselorList.tsx
+++ b/components/home/CounselorList.tsx
@@ -5,10 +5,10 @@ import {
   ActivityIndicator,
   RefreshControl,
   StyleSheet,
-  TouchableOpacity,
   View,
 } from 'react-native';
 import { Text } from 'react-native-paper';
+import { AnimatedButton } from '@/components/common/AnimatedButton';
 import { CounselorCard } from '@/components/counselor/CounselorCard';
 import { CounselorCardSkeleton } from '@/components/counselor/CounselorCardSkeleton';
 import { CounselorGridCard } from '@/components/counselor/CounselorGridCard';
@@ -102,10 +102,12 @@ export const CounselorList = React.memo(
             <Text style={styles.sortTitle}>전체 상담사</Text>
             <View style={styles.sortOptions}>
               {sortOptions.map((option) => (
-                <TouchableOpacity
+                <AnimatedButton
                   key={option.key}
                   onPress={() => onSortChange(option.key)}
                   style={[styles.sortOption, sortBy === option.key && styles.sortOptionActive]}
+                  scaleTo={0.92}
+                  springConfig={{ damping: 15, stiffness: 200 }}
                 >
                   <MaterialCommunityIcons
                     name={option.icon as IconName}
@@ -120,7 +122,7 @@ export const CounselorList = React.memo(
                   >
                     {option.label}
                   </Text>
-                </TouchableOpacity>
+                </AnimatedButton>
               ))}
             </View>
           </View>

--- a/components/home/FilterChips.tsx
+++ b/components/home/FilterChips.tsx
@@ -1,7 +1,8 @@
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import React, { useMemo } from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { Chip, Text } from 'react-native-paper';
+import { AnimatedButton } from '@/components/common/AnimatedButton';
 import { CATEGORIES } from '@/constants/categories';
 import { spacing } from '@/constants/theme';
 
@@ -24,10 +25,15 @@ export const FilterChips = React.memo(
       <View style={styles.container}>
         <View style={styles.header}>
           <Text style={styles.title}>선택된 필터</Text>
-          <TouchableOpacity onPress={onClearAll} style={styles.clearButton}>
+          <AnimatedButton
+            onPress={onClearAll}
+            style={styles.clearButton}
+            scaleTo={0.92}
+            springConfig={{ damping: 15, stiffness: 200 }}
+          >
             <MaterialCommunityIcons name="close-circle" size={18} color="#6B7280" />
             <Text style={styles.clearText}>전체 해제</Text>
-          </TouchableOpacity>
+          </AnimatedButton>
         </View>
 
         <View style={styles.chipsContainer}>

--- a/components/session/SessionListContainer.tsx
+++ b/components/session/SessionListContainer.tsx
@@ -1,10 +1,12 @@
 import { FlashList } from '@shopify/flash-list';
-import React, { type ReactElement } from 'react';
-import { RefreshControl, StyleSheet, View } from 'react-native';
+import React, { type ReactElement, useCallback } from 'react';
+import { RefreshControl, StyleSheet, View, FlatList } from 'react-native';
 import { ActivityIndicator } from 'react-native-paper';
+import { spacing } from '@/constants/theme';
 import type { Session } from '@/services/sessions/types';
 import EmptySessionState from './EmptySessionState';
 import SessionCardSkeleton from './SessionCardSkeleton';
+import { VisualSessionCard } from './VisualSessionCard';
 
 interface SessionListContainerProps {
   sessions: Session[];
@@ -20,7 +22,9 @@ interface SessionListContainerProps {
   };
   onRefresh?: () => void;
   onEndReached?: () => void;
-  renderItem: (session: Session) => ReactElement;
+  renderItem?: (session: Session) => ReactElement;
+  onBookmarkToggle?: (sessionId: number) => void;
+  layoutMode?: 'list' | 'grid'; // 레이아웃 모드 추가
 }
 
 export const SessionListContainer = React.memo(
@@ -36,8 +40,35 @@ export const SessionListContainer = React.memo(
     onRefresh,
     onEndReached,
     renderItem,
+    onBookmarkToggle,
+    layoutMode = 'list',
   }: SessionListContainerProps) => {
+    // 그리드 모드용 렌더 아이템
+    const renderGridItem = useCallback(
+      ({ item }: { item: Session }) => (
+        <View style={styles.gridItem}>
+          <VisualSessionCard
+            session={item}
+            onBookmarkToggle={() => onBookmarkToggle?.(item.sessionId)}
+          />
+        </View>
+      ),
+      [onBookmarkToggle]
+    );
+
+    // 로딩 상태
     if (isLoading && sessions.length === 0) {
+      if (layoutMode === 'grid') {
+        return (
+          <View style={styles.gridContainer}>
+            {[1, 2, 3, 4, 5, 6].map((i) => (
+              <View key={i} style={styles.skeletonItem}>
+                <SessionCardSkeleton />
+              </View>
+            ))}
+          </View>
+        );
+      }
       return (
         <View style={styles.container}>
           {[1, 2, 3].map((i) => (
@@ -47,6 +78,7 @@ export const SessionListContainer = React.memo(
       );
     }
 
+    // 빈 상태
     if (!isLoading && sessions.length === 0) {
       return (
         <EmptySessionState
@@ -58,11 +90,41 @@ export const SessionListContainer = React.memo(
       );
     }
 
+    // 그리드 레이아웃
+    if (layoutMode === 'grid') {
+      return (
+        <FlatList
+          data={sessions}
+          renderItem={renderGridItem}
+          keyExtractor={(item) => item.sessionId.toString()}
+          numColumns={2}
+          columnWrapperStyle={styles.row}
+          contentContainerStyle={styles.gridContent}
+          showsVerticalScrollIndicator={false}
+          refreshControl={
+            onRefresh ? (
+              <RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} colors={['#6B46C1']} />
+            ) : undefined
+          }
+          onEndReached={onEndReached}
+          onEndReachedThreshold={0.5}
+          ListFooterComponent={
+            hasMore || isLoading ? (
+              <View style={styles.footer}>
+                <ActivityIndicator size="small" color="#6B46C1" />
+              </View>
+            ) : null
+          }
+        />
+      );
+    }
+
+    // 리스트 레이아웃 (기존)
     return (
       <FlashList
         data={sessions}
         keyExtractor={(item) => item.sessionId.toString()}
-        renderItem={({ item }) => renderItem(item)}
+        renderItem={({ item }) => renderItem!(item)}
         refreshControl={
           onRefresh ? (
             <RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} colors={['#6B46C1']} />
@@ -98,6 +160,30 @@ const styles = StyleSheet.create({
   footer: {
     paddingVertical: 20,
     alignItems: 'center',
+  },
+  // 그리드 레이아웃 스타일
+  gridContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.md,
+    justifyContent: 'space-between',
+  },
+  gridContent: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.xl,
+  },
+  row: {
+    justifyContent: 'space-between',
+    marginBottom: spacing.lg,
+  },
+  gridItem: {
+    // 카드 자체 크기가 이미 계산되어 있음
+  },
+  skeletonItem: {
+    width: '48%',
+    marginBottom: spacing.lg,
   },
 });
 

--- a/components/session/VisualSessionCard.tsx
+++ b/components/session/VisualSessionCard.tsx
@@ -1,0 +1,256 @@
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { Image } from 'expo-image';
+import { LinearGradient } from 'expo-linear-gradient';
+import { router } from 'expo-router';
+import React, { useCallback } from 'react';
+import { Dimensions, StyleSheet, Text, View } from 'react-native';
+import { AnimatedButton } from '@/components/common/AnimatedButton';
+import { getCounselorImage } from '@/constants/counselorImages';
+import { spacing } from '@/constants/theme';
+import type { Session } from '@/services/sessions/types';
+
+// 상담내역 탭 전용 크기 (헤더 + 세그먼트 버튼 고려)
+const { width: screenWidth, height: screenHeight } = Dimensions.get('window');
+export const CARD_WIDTH = (screenWidth - spacing.lg * 2 - spacing.sm) / 2; // 정확히 2개씩
+
+// 상담내역 탭은 추가 UI 요소가 있음
+// - 상태바: ~40px
+// - 헤더: ~90px (title + subtitle)
+// - 세그먼트 버튼: ~60px
+// - 탭바: ~80px
+// - 여백: ~40px
+const availableHeight = screenHeight - 310; // 더 많은 공간 차지
+export const CARD_HEIGHT = Math.min(
+  (availableHeight - spacing.lg) / 2, // 2행이 정확히 들어가도록
+  CARD_WIDTH * 1.5 // 최대 비율 제한
+);
+
+interface VisualSessionCardProps {
+  session: Session;
+  onBookmarkToggle?: () => void;
+}
+
+export const VisualSessionCard = React.memo(
+  ({ session, onBookmarkToggle }: VisualSessionCardProps) => {
+    const handlePress = useCallback(() => {
+      router.push(`/session/${session.sessionId}`);
+    }, [session.sessionId]);
+
+    const handleBookmarkPress = useCallback((e: any) => {
+      e.stopPropagation();
+      onBookmarkToggle?.();
+    }, [onBookmarkToggle]);
+
+    const imageSource = getCounselorImage(session.avatarUrl);
+
+    const formatTime = (dateString: string) => {
+      const date = new Date(dateString);
+      const now = new Date();
+      const diffInMillis = now.getTime() - date.getTime();
+      const diffInHours = diffInMillis / (1000 * 60 * 60);
+      const diffInMinutes = diffInMillis / (1000 * 60);
+
+      if (diffInMinutes < 1) {
+        return '방금 전';
+      } else if (diffInMinutes < 60) {
+        return `${Math.floor(diffInMinutes)}분 전`;
+      } else if (diffInHours < 24) {
+        return `${Math.floor(diffInHours)}시간 전`;
+      } else {
+        const month = date.getMonth() + 1;
+        const day = date.getDate();
+        return `${month}/${day}`;
+      }
+    };
+
+    const isActive = !session.closedAt;
+
+    return (
+      <AnimatedButton
+        onPress={handlePress}
+        scaleTo={0.96}
+        springConfig={{ damping: 12, stiffness: 160 }}
+      >
+        <View style={styles.card}>
+          {/* 전체 배경 이미지 */}
+          {imageSource ? (
+            <Image
+              source={imageSource}
+              style={styles.fullImage}
+              contentFit="cover"
+              transition={200}
+            />
+          ) : (
+            <LinearGradient
+              colors={['#6B46C1', '#9333EA']}
+              start={{ x: 0, y: 0 }}
+              end={{ x: 1, y: 1 }}
+              style={styles.fullImage}
+            >
+              <Text style={styles.avatarPlaceholder}>
+                {session.counselorName?.substring(0, 2) || '철학'}
+              </Text>
+            </LinearGradient>
+          )}
+
+          {/* 그라데이션 오버레이 */}
+          <LinearGradient
+            colors={['transparent', 'rgba(0,0,0,0.7)']}
+            style={styles.overlay}
+          />
+
+          {/* 상태 뱃지 (진행중/종료) */}
+          <View style={[
+            styles.statusBadge,
+            isActive ? styles.activeBadge : styles.closedBadge
+          ]}>
+            <MaterialCommunityIcons
+              name={isActive ? 'chat-processing' : 'check-circle'}
+              size={12}
+              color="#FFFFFF"
+            />
+            <Text style={styles.statusText}>
+              {isActive ? '진행중' : '종료됨'}
+            </Text>
+          </View>
+
+          {/* 북마크 버튼 */}
+          <AnimatedButton
+            style={styles.bookmarkButton}
+            onPress={handleBookmarkPress}
+            scaleTo={0.85}
+            springConfig={{ damping: 15, stiffness: 200 }}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          >
+            <MaterialCommunityIcons
+              name={session.isBookmarked ? 'star' : 'star-outline'}
+              size={18}
+              color={session.isBookmarked ? '#FFD700' : '#FFFFFF'}
+            />
+          </AnimatedButton>
+
+          {/* 하단 정보 영역 */}
+          <View style={styles.infoContainer}>
+            <Text style={styles.title} numberOfLines={2}>
+              {session.title}
+            </Text>
+            <View style={styles.bottomRow}>
+              <Text style={styles.counselorName} numberOfLines={1}>
+                {session.counselorName}
+              </Text>
+              <Text style={styles.time}>
+                {formatTime(session.closedAt || session.lastMessageAt)}
+              </Text>
+            </View>
+          </View>
+        </View>
+      </AnimatedButton>
+    );
+  },
+);
+
+const styles = StyleSheet.create({
+  card: {
+    width: CARD_WIDTH,
+    height: CARD_HEIGHT,
+    borderRadius: 16,
+    overflow: 'hidden',
+    backgroundColor: '#F3F4F6',
+    elevation: 6,
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 3,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 6,
+  },
+  fullImage: {
+    position: 'absolute',
+    width: '100%',
+    height: '100%',
+    backgroundColor: '#F3F4F6',
+  },
+  avatarPlaceholder: {
+    fontSize: CARD_WIDTH * 0.25,
+    fontWeight: '700',
+    fontFamily: 'Pretendard-Bold',
+    color: '#FFFFFF',
+    textAlign: 'center',
+    marginTop: CARD_HEIGHT * 0.35,
+  },
+  overlay: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: '35%', // 즐겨찾기와 동일
+  },
+  statusBadge: {
+    position: 'absolute',
+    top: 12,
+    left: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 12,
+  },
+  activeBadge: {
+    backgroundColor: 'rgba(16, 185, 129, 0.9)',
+  },
+  closedBadge: {
+    backgroundColor: 'rgba(107, 70, 193, 0.9)',
+  },
+  statusText: {
+    fontSize: 11,
+    fontFamily: 'Pretendard-Medium',
+    color: '#FFFFFF',
+  },
+  bookmarkButton: {
+    position: 'absolute',
+    top: 12,
+    right: 12,
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  infoContainer: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    padding: spacing.md,
+    paddingBottom: spacing.sm,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '700',
+    fontFamily: 'Pretendard-Bold',
+    color: '#FFFFFF',
+    marginBottom: 6,
+    textShadowColor: 'rgba(0, 0, 0, 0.5)',
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 2,
+  },
+  bottomRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  counselorName: {
+    fontSize: 13,
+    fontFamily: 'Pretendard-Medium',
+    color: 'rgba(255, 255, 255, 0.95)',
+    flex: 1,
+  },
+  time: {
+    fontSize: 12,
+    fontFamily: 'Pretendard-Regular',
+    color: 'rgba(255, 255, 255, 0.9)',
+  },
+});

--- a/hooks/useCounselors.ts
+++ b/hooks/useCounselors.ts
@@ -51,13 +51,19 @@ export const useToggleFavorite = () => {
     onSuccess: (_, { counselorId, isFavorite }) => {
       // 즐겨찾기 목록 새로고침
       queryClient.invalidateQueries({ queryKey: ['favorites'] });
-      // 상담사 목록 새로고침 (isFavorite 상태 반영)
+
+      // 무한 스크롤 상담사 목록 새로고침 (중요!)
+      queryClient.invalidateQueries({ queryKey: ['counselors', 'infinite'] });
+
+      // 일반 상담사 목록도 새로고침
       queryClient.invalidateQueries({ queryKey: ['counselors'] });
+
       // 해당 상담사 상세 정보 업데이트
       queryClient.setQueryData(['counselor', counselorId], (old: CounselorDetail | undefined) => {
         if (!old) return old;
         return { ...old, isFavorite: !isFavorite };
       });
+
       toast.show(
         isFavorite ? '즐겨찾기에서 제거되었습니다' : '즐겨찾기에 추가되었습니다',
         'success',

--- a/hooks/useSessionActions.ts
+++ b/hooks/useSessionActions.ts
@@ -57,6 +57,17 @@ export const useSessionActions = ({
     onSuccess: () => {
       setShowEndDialog(false);
       setShowRatingDialog(true);
+
+      // 세션 목록 캐시 즉시 무효화
+      queryClient.invalidateQueries({ queryKey: ['sessions'] });
+
+      // 특히 진행중/종료됨 탭 갱신
+      queryClient.invalidateQueries({
+        queryKey: ['sessions', 1, 20, undefined, false] // 진행중
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['sessions', 1, 20, undefined, true] // 종료됨
+      });
     },
     onError: () => {
       toast.show('세션 종료에 실패했습니다', 'error');

--- a/hooks/useStartSession.ts
+++ b/hooks/useStartSession.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { startSession } from '@/services/sessions';
+import type { CreateSessionRequest, StartSessionResponse } from '@/services/sessions/types';
+import { useToast } from '@/store/toastStore';
+
+export const useStartSession = () => {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  return useMutation<StartSessionResponse, Error, CreateSessionRequest>({
+    mutationFn: ({ counselorId }) => startSession(counselorId),
+    onSuccess: () => {
+      // 세션 목록 캐시 무효화 - 모든 세션 관련 쿼리 갱신
+      queryClient.invalidateQueries({ queryKey: ['sessions'] });
+
+      // 특히 진행중 세션 목록 즉시 갱신
+      queryClient.invalidateQueries({
+        queryKey: ['sessions', 1, 20, undefined, false]
+      });
+    },
+    onError: (error) => {
+      console.error('Session start failed:', error);
+      toast.show('세션 시작에 실패했습니다', 'error');
+    },
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "react-native-app-intro-slider": "^4.0.4",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-get-random-values": "~1.11.0",
-        "react-native-gifted-chat": "^2.6.4",
+        "react-native-gifted-chat": "^2.8.1",
         "react-native-paper": "^5.14.5",
         "react-native-reanimated": "~4.1.0",
         "react-native-safe-area-context": "~5.6.0",
@@ -14428,44 +14428,28 @@
       }
     },
     "node_modules/react-native-gifted-chat": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/react-native-gifted-chat/-/react-native-gifted-chat-2.6.4.tgz",
-      "integrity": "sha512-Ut31I1w6g4hG/iMyC1mVNVPZCNAUfijbJaEbRmKQnTPG+nAvYFje57OHr5coe9w+IBWsJKKoNvaI4h8w9Il5aQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/react-native-gifted-chat/-/react-native-gifted-chat-2.8.1.tgz",
+      "integrity": "sha512-x4Kq0YvmaHqQg/ENAmFzwcjJyH31cGrCWETFzUMmTZgWsXkkiJ1MamTnkLGQp6deVxM6G0QNxrF7IZnBOeMbsw==",
       "license": "MIT",
       "dependencies": {
-        "@expo/react-native-action-sheet": "^4.1.0",
+        "@expo/react-native-action-sheet": "^4.1.1",
         "@types/lodash.isequal": "^4.5.8",
         "dayjs": "^1.11.13",
         "lodash.isequal": "^4.5.0",
-        "prop-types": "^15.8.1",
         "react-native-communications": "^2.2.1",
         "react-native-iphone-x-helper": "^1.3.1",
-        "react-native-lightbox-v2": "^0.9.0",
-        "react-native-parsed-text": "^0.0.22",
-        "uuid": "^10.0.0"
+        "react-native-lightbox-v2": "^0.9.2",
+        "react-native-parsed-text": "^0.0.22"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "react": "*",
+        "react": ">=18.0.0",
         "react-native": "*",
-        "react-native-get-random-values": "*",
-        "react-native-reanimated": "*",
-        "react-native-safe-area-context": "*"
-      }
-    },
-    "node_modules/react-native-gifted-chat/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+        "react-native-keyboard-controller": ">=1.0.0",
+        "react-native-reanimated": ">=3.0.0"
       }
     },
     "node_modules/react-native-iphone-x-helper": {
@@ -14485,6 +14469,21 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-keyboard-controller": {
+      "version": "1.18.6",
+      "resolved": "https://registry.npmjs.org/react-native-keyboard-controller/-/react-native-keyboard-controller-1.18.6.tgz",
+      "integrity": "sha512-K/RMw3MdtuykkACFN5d9RTapAcO0v4T34gmSyHkEraU5UsX+fxEHd6j4MvL7KUihvmLLod0NV/mQC0nL4cOurw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "react-native-is-edge-to-edge": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-reanimated": ">=3.0.0"
       }
     },
     "node_modules/react-native-lightbox-v2": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-native-app-intro-slider": "^4.0.4",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-get-random-values": "~1.11.0",
-    "react-native-gifted-chat": "^2.6.4",
+    "react-native-gifted-chat": "^2.8.1",
     "react-native-paper": "^5.14.5",
     "react-native-reanimated": "~4.1.0",
     "react-native-safe-area-context": "~5.6.0",


### PR DESCRIPTION
## 📝 Summary
상담내역 탭의 UI/UX를 전반적으로 개선하고 즐겨찾기 섹션과 일관된 디자인 패턴을 적용했습니다.

## ✨ Changes
### 상담내역 탭 개선
- 헤더에 아이콘 추가 및 타이틀 스타일링 개선
- Material Design 3 칩 패턴 적용 (SegmentedButtons 대체)
- 진행중/종료됨/북마크 탭에 아이콘 추가
- 탭 위치 왼쪽 정렬로 가독성 향상

### 그리드 레이아웃 추가
- VisualSessionCard 컴포넌트 구현 (이미지 배경 카드)
- SessionListContainer에 layoutMode prop 추가 (list/grid)
- 반응형 카드 크기 계산 로직 구현
- expo-image 사용으로 이미지 로딩 성능 최적화

### 채팅 헤더 간소화
- 상담사 이름 표시 제거 (제목만 표시)
- 여백 최적화 (padding 16px → 8px)
- 공간 효율성 향상

### 성능 및 UX 개선
- 무한 스크롤 구현 (페이지네이션)
- React Query 캐시 무효화로 실시간 업데이트
- useStartSession 훅 추가 (세션 생성 및 캐시 관리)
- 컴포넌트 재사용성 향상

## 📱 Screenshots
- 상담내역 탭: 개선된 헤더와 칩 디자인
- 그리드 레이아웃: 2열 비주얼 카드 배치
- 채팅 헤더: 간소화된 디자인

## 🧪 Test Plan
- [x] 상담내역 탭 진행중/종료됨/북마크 필터링 동작 확인
- [x] 무한 스크롤 및 페이지네이션 동작 확인
- [x] 세션 카드 북마크 토글 기능 확인
- [x] 채팅 화면 헤더 표시 확인
- [x] 새 세션 시작 후 목록 즉시 갱신 확인