### PR TITLE
feat: Google Play 검토용 로그인 지원

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -22,7 +22,7 @@ const config = {
       backgroundColor: '#ffffff',
     },
     package: 'com.mindtalk.app',
-    versionCode: 2,
+    versionCode: 4,
   },
   web: {
     favicon: './assets/favicon.png',
@@ -48,7 +48,7 @@ const config = {
   extra: {
     router: {},
     eas: {
-      projectId: '5eaf2255-a092-4c80-ab46-ec234ad943b8',
+      projectId: '6dac6037-b59d-4bb0-975f-d1e97ffc4361',
     },
     apiUrl: process.env.EXPO_PUBLIC_API_BASE_URL
       ? `${process.env.EXPO_PUBLIC_API_BASE_URL}/api`

--- a/components/auth/LoadingOverlay.tsx
+++ b/components/auth/LoadingOverlay.tsx
@@ -5,24 +5,28 @@ import { borderRadius, colors, shadows, spacing } from '@/constants/theme';
 
 interface LoadingOverlayProps {
   isVisible: boolean;
-  isGoogleLoading: boolean;
+  spinnerColor?: string;
+  message?: string;
 }
 
-export const LoadingOverlay = React.memo(({ isVisible, isGoogleLoading }: LoadingOverlayProps) => {
-  if (!isVisible) return null;
+export const LoadingOverlay = React.memo(
+  ({
+    isVisible,
+    spinnerColor = colors.brand.google,
+    message = '로그인 중...',
+  }: LoadingOverlayProps) => {
+    if (!isVisible) return null;
 
-  return (
-    <View style={styles.loadingOverlay}>
-      <View style={styles.loadingCard}>
-        <ActivityIndicator
-          size="large"
-          color={isGoogleLoading ? colors.brand.google : colors.brand.kakao}
-        />
-        <Text style={styles.loadingText}>로그인 중...</Text>
+    return (
+      <View style={styles.loadingOverlay}>
+        <View style={styles.loadingCard}>
+          <ActivityIndicator size="large" color={spinnerColor} />
+          <Text style={styles.loadingText}>{message}</Text>
+        </View>
       </View>
-    </View>
-  );
-});
+    );
+  },
+);
 
 const styles = StyleSheet.create({
   loadingOverlay: {


### PR DESCRIPTION
- 리뷰 모드시 로그인 화면에 '검토용 계정' 버튼을 노출하고 테스트 엔드포인트 호출\n- 로그인 진행 중 로딩 오버레이를 재사용하도록 개선해 프로바이더별 메시지/컬러 지정\n- lint 및 typecheck 완료